### PR TITLE
Update Netbeans repository url in order to prevent build error.

### DIFF
--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -63,7 +63,7 @@
         <repository>
             <id>netbeans</id>
             <name>NetBeans</name>
-            <url>http://bits.netbeans.org/nexus/content/groups/netbeans/</url>
+            <url>https://netbeans.apidesign.org/maven2/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Building plugins inside the repository result in a build error:

Could not resolve dependencies for project MyProject: Failed to collect dependencies at org.gephi:graph-api:jar:0.9.2 -> org.gephi:project-api:jar:0.9.2 -> org.netbeans.api:org-openide-filesystems:jar:RELEASE82: Failed to read artifact descriptor for org.netbeans.api:org-openide-filesystems:jar:RELEASE82: Could not transfer artifact org.netbeans.api:org-openide-filesystems:pom:RELEASE82 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [netbeans (http://bits.netbeans.org/nexus/content/groups/netbeans/, default, releases)]